### PR TITLE
Use semver versioning for socket.io-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build_test
 .jshintrc
 .validate.json
 .vscode
+.eslintcache
+yarn.lock

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var gulp = require('gulp')
 var $ = require('gulp-load-plugins')()
 var runSequence = require('run-sequence').use(gulp)
 
-require('../yjs/gulpfile.helper.js')(gulp, {
+require('yjs/gulpfile.helper.js')(gulp, {
   polyfills: [],
   entry: './src/Websockets-client.js',
   targetName: 'y-websockets-client.js',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "http://y-js.org",
   "dependencies": {
-    "socket.io-client": "1.3.7"
+    "socket.io-client": "^1.3.7"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.4",
@@ -46,16 +46,30 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-runtime": "^6.1.18",
     "babelify": "^7.2.0",
+    "browserify": "^14.4.0",
     "fs": "0.0.2",
     "gulp": "^3.9.0",
+    "gulp-bump": "^2.7.0",
+    "gulp-header": "^1.8.8",
+    "gulp-if": "^2.0.2",
+    "gulp-jasmine": "^2.4.2",
     "gulp-load-plugins": "^1.1.0",
-    "gulp-prompt": "^0.1.2",
+    "gulp-prompt": "^0.2.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.6.3",
+    "gulp-sourcemaps": "^2.6.0",
+    "gulp-uglify": "^3.0.0",
+    "gulp-watch": "^4.3.11",
     "http": "0.0.0",
+    "minimist": "^1.2.0",
     "pre-commit": "^1.1.2",
     "run-sequence": "^1.1.4",
     "socket.io": "^1.3.7",
     "standard": "^5.3.1",
-    "utf-8-validate": "^1.2.1"
+    "utf-8-validate": "^1.2.1",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
+    "yjs": "^12.3.1"
   },
   "peerDependencies": {
     "yjs": "^11.0.0 || ^12.0.0"


### PR DESCRIPTION
- Use semver versioning for socket.io-client
- Make gulp scripts more accessible for newcomers

Hello @dmonad!

I ran a Node Security Project check and found that `socket.io-client@1.3.7` had a list of vulnerabilities:

```
> nsp check
(+) 4 vulnerabilities found
┌───────────────┬───────────────────────────────────────────────────────────────┐
│               │ DoS due to excessively large websocket message                │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Name          │ ws                                                            │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ CVSS          │ 7.5 (High)                                                    │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Installed     │ 0.8.0                                                         │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=1.1.0                                                       │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Patched       │ >=1.1.1                                                       │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Path          │ y-websockets-client@8.0.16 > socket.io-client@1.3.7 > engine… │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/120                        │
└───────────────┴───────────────────────────────────────────────────────────────┘
┌───────────────┬───────────────────────────────────────────────────────────────┐
│               │ Insecure Defaults Allow MITM Over TLS                         │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Name          │ engine.io-client                                              │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ CVSS          │ 6.8 (Medium)                                                  │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Installed     │ 1.5.4                                                         │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <= 1.6.8                                                      │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Patched       │ >= 1.6.9                                                      │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Path          │ y-websockets-client@8.0.16 > socket.io-client@1.3.7 > engine… │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/99                         │
└───────────────┴───────────────────────────────────────────────────────────────┘
┌───────────────┬───────────────────────────────────────────────────────────────┐
│               │ Remote Memory Disclosure                                      │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Name          │ ws                                                            │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ CVSS          │ 6.5 (Medium)                                                  │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Installed     │ 0.8.0                                                         │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <= 1.0.0                                                      │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Patched       │ >= 1.0.1                                                      │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Path          │ y-websockets-client@8.0.16 > socket.io-client@1.3.7 > engine… │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/67                         │
└───────────────┴───────────────────────────────────────────────────────────────┘
┌───────────────┬───────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                          │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Name          │ ms                                                            │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ CVSS          │ 5.3 (Medium)                                                  │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Installed     │ 0.6.2                                                         │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Vulnerable    │ <=0.7.0                                                       │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Patched       │ >0.7.0                                                        │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ Path          │ y-websockets-client@8.0.16 > socket.io-client@1.3.7 > engine… │
├───────────────┼───────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/46                         │
└───────────────┴───────────────────────────────────────────────────────────────┘
```

I wasn't sure why you pinned it to that version, but I was able to do some local tests successfully after upgrading to the latest `socket.io-client@^1`.

This also includes the dev dependencies needed to run the `gulp dist` script without depending on the `yjs` repo to be cloned and installed in an adjacent folder.

Let me know what you think!